### PR TITLE
fix: letters overlappen op mobile

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -1,20 +1,20 @@
 <div class="paragraph">
-	<h1 class="text-5xl leading-6 font-medium text-gray-900 space-y-8 divide-y divide-gray-200">
-		Ik wil mijn legitimatie!
-	</h1>
-	<p class="mt-1 text-lg text-gray-700"><br>
+    <h1 class="text-5xl font-medium text-gray-900 space-y-8 divide-y divide-gray-200">
+        Ik wil mijn legitimatie!
+    </h1>
+    <p class="mt-1 text-lg text-gray-700"><br>
 
-		In Utrecht is er een wachttijd van 6 weken voor het aanvragen of verlengen van een paspoort, identiteitskaart of
-		rijbewijs.
-		Wat nou als je binnenkort op vakantie gaat of net bent geslaagd voor je rij-examen en graag je rijbewijs wilt?
-		Je zou kunnen betalen voor een spoedafspraak (kost extra geld) of je maakt gebruik van
-		<b>ikwilmijnlegitimatie</b>!
-		<br>
-		<br>
-		De gemeente heeft te maken met annuleringen van afspraken.
-		Dit betekent dat er een afspraak vrijkomt (op kort termijn) die jij zou kunnen boeken.
-		Echter, je hebt geen zin om continue de website van de gemeente in de gaten te houden wachtend op een
-		vrijkomende afspraak.
-		Daar komt <b>ikwilmijnlegitimatie</b> in het spel.
-		</p>
+        In Utrecht is er een wachttijd van 6 weken voor het aanvragen of verlengen van een paspoort, identiteitskaart of
+        rijbewijs.
+        Wat nou als je binnenkort op vakantie gaat of net bent geslaagd voor je rij-examen en graag je rijbewijs wilt?
+        Je zou kunnen betalen voor een spoedafspraak (kost extra geld) of je maakt gebruik van
+        <b>ikwilmijnlegitimatie</b>!
+        <br>
+        <br>
+        De gemeente heeft te maken met annuleringen van afspraken.
+        Dit betekent dat er een afspraak vrijkomt (op kort termijn) die jij zou kunnen boeken.
+        Echter, je hebt geen zin om continue de website van de gemeente in de gaten te houden wachtend op een
+        vrijkomende afspraak.
+        Daar komt <b>ikwilmijnlegitimatie</b> in het spel.
+    </p>
 </div>

--- a/app/templates/message_for_gemeente.html
+++ b/app/templates/message_for_gemeente.html
@@ -1,10 +1,10 @@
 <div class="paragraph">
-	<h2 class="text-3xl pb-2 leading-6 font-medium text-gray-900 space-y-8 divide-y divide-gray-200">
-		Bericht voor de Gemeente Utrecht
-	</h2>
-	<p class="mt-1 text-lg text-gray-700">
-		Ik begrijp dat het super druk is en afspraken die worden geannuleerd helpen daar niet bij.
-		Met <b>ikwilmijnlegitimatie</b> hoop ik jullie te helpen met de doorstroom van afspraken!
-		Zo komen we snel weer op het oude niveau terecht waar de wachttijd voor een afspraak 1 week was.
-	</p>
+    <h2 class="text-3xl pb-2 font-medium text-gray-900 space-y-8 divide-y divide-gray-200">
+        Bericht voor de Gemeente Utrecht
+    </h2>
+    <p class="mt-1 text-lg text-gray-700">
+        Ik begrijp dat het super druk is en afspraken die worden geannuleerd helpen daar niet bij.
+        Met <b>ikwilmijnlegitimatie</b> hoop ik jullie te helpen met de doorstroom van afspraken!
+        Zo komen we snel weer op het oude niveau terecht waar de wachttijd voor een afspraak 1 week was.
+    </p>
 </div>

--- a/app/templates/total_people_helped.html
+++ b/app/templates/total_people_helped.html
@@ -1,9 +1,10 @@
 <div class="paragraph">
-	<h2 class="text-3xl pb-2 leading-6 font-medium text-gray-900 space-y-8 divide-y divide-gray-200">
-		Hoeveel mensen geholpen aan een afspraak?
-	</h2>
-	<p class="mt-1 text-lg text-gray-700">
+    <h2 class="text-3xl pb-2 font-medium text-gray-900 space-y-8 divide-y divide-gray-200">
+        Hoeveel mensen geholpen aan een afspraak?
+    </h2>
+    <p class="mt-1 text-lg text-gray-700">
 
-		<b>ikwilmijnlegitimatie</b> heeft tot en met nu {{ total_people_helped }} mensen geholpen aan een afspraak bij de Gemeente Utrecht!
-	</p>
+        <b>ikwilmijnlegitimatie</b> heeft tot en met nu {{ total_people_helped }} mensen geholpen aan een afspraak bij
+        de Gemeente Utrecht!
+    </p>
 </div>


### PR DESCRIPTION
Op smalle screen sizes zorgt `leading-6` class voor overlappende letters
<img width="501" alt="Schermafbeelding 2022-04-26 om 22 09 43" src="https://user-images.githubusercontent.com/33266555/165424533-30590c5b-fa8e-4673-8b19-72dc32df7dc6.png">
.